### PR TITLE
Reduce http://-dependence

### DIFF
--- a/api-guide/authentication.html
+++ b/api-guide/authentication.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Authentication - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Authentication, API Reference, Custom authentication, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -528,9 +528,9 @@ class ExampleAuthentication(authentication.BaseAuthentication):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/content-negotiation.html
+++ b/api-guide/content-negotiation.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Content negotiation - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Content negotiation, Custom content negotiation">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -289,9 +289,9 @@ class NoNegotiationView(APIView):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/exceptions.html
+++ b/api-guide/exceptions.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Exceptions - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Exceptions, API Reference">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -326,9 +326,9 @@ class ServiceUnavailable(APIException):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/fields.html
+++ b/api-guide/fields.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Serializer fields - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Serializer fields, Generic Fields, Typed Fields, Custom fields, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -482,9 +482,9 @@ class ColourField(serializers.WritableField):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/filtering.html
+++ b/api-guide/filtering.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Filtering - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Filtering, Generic Filtering, API Guide, Custom generic filtering, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -531,9 +531,9 @@ class ProductFilter(django_filters.FilterSet):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/format-suffixes.html
+++ b/api-guide/format-suffixes.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Format suffixes - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Format suffixes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -265,9 +265,9 @@ def comment_list(request, format=None):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/generic-views.html
+++ b/api-guide/generic-views.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Generic views - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Generic views, API Reference, Mixins, Concrete View Classes, Customizing the generic views, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -495,9 +495,9 @@ class BaseRetrieveUpdateDestroyView(MultipleFieldLookupMixin,
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/pagination.html
+++ b/api-guide/pagination.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Pagination - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Pagination, Custom pagination serializers, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -347,9 +347,9 @@ class CustomPaginationSerializer(pagination.BasePaginationSerializer):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/parsers.html
+++ b/api-guide/parsers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Parsers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Parsers, API Reference, Custom parsers, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -353,9 +353,9 @@ def parse(self, stream, media_type=None, parser_context=None):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/permissions.html
+++ b/api-guide/permissions.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Permissions - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Permissions, API Reference, Custom permissions, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -403,9 +403,9 @@ class BlacklistPermission(permissions.BasePermission):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/relations.html
+++ b/api-guide/relations.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Serializer relations - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Serializer relations, API Reference, Nested relationships, Custom relational fields, Further notes, Third Party Packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -327,7 +327,7 @@ class Track(models.Model):
 <p>By default this field is read-write, although you can change this behavior using the <code>read_only</code> flag.</p>
 <p><strong>Arguments</strong>:</p>
 <ul>
-<li><code>view_name</code> - The view name that should be used as the target of the relationship.  If you're using <a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers#defaultrouter">the standard router classes</a> this wil be a string with the format <code>&lt;modelname&gt;-detail</code>. <strong>required</strong>.</li>
+<li><code>view_name</code> - The view name that should be used as the target of the relationship.  If you're using <a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers#defaultrouter">the standard router classes</a> this wil be a string with the format <code>&lt;modelname&gt;-detail</code>. <strong>required</strong>.</li>
 <li><code>many</code> - If applied to a to-many relationship, you should set this argument to <code>True</code>.</li>
 <li><code>required</code> - If set to <code>False</code>, the field will accept values of <code>None</code> or the empty-string for nullable relationships.</li>
 <li><code>queryset</code> - By default <code>ModelSerializer</code> classes will use the default queryset for the relationship.  <code>Serializer</code> classes must either set a queryset explicitly, or set <code>read_only=True</code>.</li>
@@ -385,7 +385,7 @@ class Track(models.Model):
 <p>This field is always read-only.</p>
 <p><strong>Arguments</strong>:</p>
 <ul>
-<li><code>view_name</code> - The view name that should be used as the target of the relationship.  If you're using <a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers#defaultrouter">the standard router classes</a> this wil be a string with the format <code>&lt;model_name&gt;-detail</code>.  <strong>required</strong>.</li>
+<li><code>view_name</code> - The view name that should be used as the target of the relationship.  If you're using <a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers#defaultrouter">the standard router classes</a> this wil be a string with the format <code>&lt;model_name&gt;-detail</code>.  <strong>required</strong>.</li>
 <li><code>lookup_field</code> - The field on the target that should be used for the lookup.  Should correspond to a URL keyword argument on the referenced view.  Default is <code>'pk'</code>.</li>
 <li><code>format</code> - If using format suffixes, hyperlinked fields will use the same format suffix for the target unless overridden by using the <code>format</code> argument.</li>
 </ul>
@@ -597,9 +597,9 @@ In the 2.4 release, these parts of the API will be removed entirely.</p>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/renderers.html
+++ b/api-guide/renderers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Renderers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Renderers, API Reference, Custom renderers, Advanced renderer usage, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -313,7 +313,7 @@ def user_count_view(request, format=None):
 <p>The javascript callback function must be set by the client including a <code>callback</code> URL query parameter.  For example <code>http://example.com/api/users?callback=jsonpCallback</code>.  If the callback function is not explicitly set by the client it will default to <code>'callback'</code>.</p>
 <hr />
 <p><strong>Warning</strong>: If you require cross-domain AJAX requests, you should almost certainly be using the more modern approach of <a href="http://www.w3.org/TR/cors/">CORS</a> as an alternative to <code>JSONP</code>.  See the <a href="../topics/ajax-csrf-cors">CORS documentation</a> for more details.</p>
-<p>The <code>jsonp</code> approach is essentially a browser hack, and is <a href="http://stackoverflow.com/questions/613962/is-jsonp-safe-to-use">only appropriate for globally  readable API endpoints</a>, where <code>GET</code> requests are unauthenticated and do not require any user permissions.</p>
+<p>The <code>jsonp</code> approach is essentially a browser hack, and is <a href="//stackoverflow.com/questions/613962/is-jsonp-safe-to-use">only appropriate for globally  readable API endpoints</a>, where <code>GET</code> requests are unauthenticated and do not require any user permissions.</p>
 <hr />
 <p><strong>.media_type</strong>: <code>application/javascript</code></p>
 <p><strong>.format</strong>: <code>'.jsonp'</code></p>
@@ -539,9 +539,9 @@ In this case you can underspecify the media types it should respond to, by using
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/requests.html
+++ b/api-guide/requests.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Requests - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Requests, Request parsing, Authentication, Browser enhancements, Standard HttpRequest attributes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -295,9 +295,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/responses.html
+++ b/api-guide/responses.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Responses - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Responses, Creating responses, Attributes, Standard HttpResponse attributes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -278,9 +278,9 @@ response['Cache-Control'] = 'no-cache'
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/reverse.html
+++ b/api-guide/reverse.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Returning URLs - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Returning URLs">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -253,9 +253,9 @@ class APIRootView(APIView):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/routers.html
+++ b/api-guide/routers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Routers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Routers, API Guide, Custom Routers, Third Party Packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -426,9 +426,9 @@ app.router.register_model(MyModel)
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/serializers.html
+++ b/api-guide/serializers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Serializers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Serializers, ModelSerializer, HyperlinkedModelSerializer, Advanced serializer usage, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -692,9 +692,9 @@ The <code>ModelSerializer</code> class lets you automatically create a Serialize
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/settings.html
+++ b/api-guide/settings.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Settings - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Settings, API Reference">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -451,9 +451,9 @@ If set to <code>None</code> then generic filtering is disabled.</p>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/status-codes.html
+++ b/api-guide/status-codes.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Status Codes - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Status Codes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -313,9 +313,9 @@ is_server_error()   # 5xx
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/testing.html
+++ b/api-guide/testing.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Testing - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Testing, APIRequestFactory, APIClient, Test cases, Testing responses, Configuration">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -425,9 +425,9 @@ self.assertEqual(response.content, '{"username": "lauren", "id": 4}')
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/throttling.html
+++ b/api-guide/throttling.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Throttling - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Throttling, API Reference, Custom throttles">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -362,9 +362,9 @@ class UploadView(APIView):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/views.html
+++ b/api-guide/views.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Class Based Views - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Class Based Views, Function Based Views">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -334,9 +334,9 @@ def view(request):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/api-guide/viewsets.html
+++ b/api-guide/viewsets.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>ViewSets - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, ViewSets, API Reference, Custom ViewSet base classes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -419,9 +419,9 @@ class UserViewSet(viewsets.ModelViewSet):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/index.html
+++ b/index.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Django REST framework - Web APIs for Django</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Django REST framework">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -210,10 +210,10 @@ a.fusion-poweredby {
 
           <div id="main-content" class="span9">
             <p class="badges" height=20px>
-<iframe src="http://ghbtns.com/github-btn.html?user=tomchristie&amp;repo=django-rest-framework&amp;type=watch&amp;count=true" class="github-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
+<iframe src="//ghbtns.com/github-btn.html?user=tomchristie&amp;repo=django-rest-framework&amp;type=watch&amp;count=true" class="github-star-button" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
 
-<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://tomchristie.github.io/rest-framework-2-docs" data-text="Checking out the totally awesome Django REST framework! http://tomchristie.github.io/rest-framework-2-docs" data-count="none"></a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="http://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<a href="https://twitter.com/share" class="twitter-share-button" data-url="//tomchristie.github.io/rest-framework-2-docs" data-text="Checking out the totally awesome Django REST framework! https://tomchristie.github.io/rest-framework-2-docs" data-count="none"></a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <img src="https://secure.travis-ci.org/tomchristie/django-rest-framework.png?branch=master" class="travis-build-image">
 </p>
@@ -239,12 +239,12 @@ a.fusion-poweredby {
 <p>Django REST framework is a powerful and flexible toolkit that makes it easy to build Web APIs.</p>
 <p>Some reasons you might want to use REST framework:</p>
 <ul>
-<li>The <a href="http://restframework.herokuapp.com/">Web browseable API</a> is a huge usability win for your developers.</li>
+<li>The <a href="//restframework.herokuapp.com/">Web browseable API</a> is a huge usability win for your developers.</li>
 <li><a href="api-guide/authentication">Authentication policies</a> including <a href="api-guide/authentication#oauthauthentication">OAuth1a</a> and <a href="api-guide/authentication#oauth2authentication">OAuth2</a> out of the box.</li>
 <li><a href="api-guide/serializers">Serialization</a> that supports both <a href="api-guide/serializers#modelserializer">ORM</a> and <a href="api-guide/serializers#serializers">non-ORM</a> data sources.</li>
 <li>Customizable all the way down - just use <a href="api-guide/views#function-based-views">regular function-based views</a> if you don't need the <a href="api-guide/generic-views">more</a> <a href="api-guide/viewsets">powerful</a> <a href="api-guide/routers">features</a>.</li>
 <li><a href=".">Extensive documentation</a>, and <a href="https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework">great community support</a>.</li>
-<li>Used and trusted by large companies such as <a href="http://www.mozilla.org/en-US/about/">Mozilla</a> and <a href="https://www.eventbrite.co.uk/about/">Eventbrite</a>.</li>
+<li>Used and trusted by large companies such as <a href="https://www.mozilla.org/en-US/about/">Mozilla</a> and <a href="https://www.eventbrite.co.uk/about/">Eventbrite</a>.</li>
 </ul>
 <hr />
 <p><img alt="Screenshot" src="img/quickstart.png" /></p>
@@ -343,7 +343,7 @@ urlpatterns = [
 <li><a href="tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships &amp; hyperlinked APIs</a></li>
 <li><a href="tutorial/6-viewsets-and-routers">6 - Viewsets &amp; routers</a></li>
 </ul>
-<p>There is a live example API of the finished tutorial API for testing purposes, <a href="http://restframework.herokuapp.com/">available here</a>.</p>
+<p>There is a live example API of the finished tutorial API for testing purposes, <a href="//restframework.herokuapp.com/">available here</a>.</p>
 <h2 id="api-guide">API Guide</h2>
 <p>The API guide is your complete reference manual to all the functionality provided by REST framework.</p>
 <ul>
@@ -394,11 +394,11 @@ urlpatterns = [
 the repository, run the test suite and contribute changes back to REST
 Framework.</p>
 <h2 id="support">Support</h2>
-<p>For support please see the <a href="https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework">REST framework discussion group</a>, try the  <code>#restframework</code> channel on <code>irc.freenode.net</code>, search <a href="https://botbot.me/freenode/restframework/">the IRC archives</a>, or raise a  question on <a href="http://stackoverflow.com/">Stack Overflow</a>, making sure to include the <a href="http://stackoverflow.com/questions/tagged/django-rest-framework">'django-rest-framework'</a> tag.</p>
+<p>For support please see the <a href="https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework">REST framework discussion group</a>, try the  <code>#restframework</code> channel on <code>irc.freenode.net</code>, search <a href="https://botbot.me/freenode/restframework/">the IRC archives</a>, or raise a  question on <a href="//stackoverflow.com/">Stack Overflow</a>, making sure to include the <a href="//stackoverflow.com/questions/tagged/django-rest-framework">'django-rest-framework'</a> tag.</p>
 <p><a href="http://dabapps.com/services/build/api-development/">Paid support is available</a> from <a href="http://dabapps.com">DabApps</a>, and can include work on REST framework core, or support with building your REST framework API.  Please <a href="http://dabapps.com/contact/">contact DabApps</a> if you'd like to discuss commercial support options.</p>
 <p>For updates on REST framework development, you may also want to follow <a href="https://twitter.com/_tomchristie">the author</a> on Twitter.</p>
 <p><a style="padding-top: 10px" href="https://twitter.com/_tomchristie" class="twitter-follow-button" data-show-count="false">Follow @_tomchristie</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
 <h2 id="security">Security</h2>
 <p>If you believe you’ve found something in Django REST framework which has security implications, please <strong>do not raise the issue in a public forum</strong>.</p>
 <p>Send a description of the issue via email to <a href="mailto:rest-framework-security@googlegroups.com">rest-framework-security@googlegroups.com</a>.  The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.</p>
@@ -437,9 +437,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/2.2-announcement.html
+++ b/topics/2.2-announcement.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>REST framework 2.2 announcement - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, REST framework 2.2 announcement">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -224,7 +224,7 @@ a.fusion-poweredby {
 </ul>
 <p>Note that in line with Django's policy, any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.</p>
 <h2 id="community">Community</h2>
-<p>As of the 2.2 merge, we've also hit an impressive milestone.  The number of committers listed in <a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">the credits</a>, is now at over <strong>one hundred individuals</strong>.  Each name on that list represents at least one merged pull request, however large or small.</p>
+<p>As of the 2.2 merge, we've also hit an impressive milestone.  The number of committers listed in <a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">the credits</a>, is now at over <strong>one hundred individuals</strong>.  Each name on that list represents at least one merged pull request, however large or small.</p>
 <p>Our <a href="https://groups.google.com/forum/?fromgroups#!forum/django-rest-framework">mailing list</a> and #restframework IRC channel are also very active, and we've got a really impressive rate of development both on REST framework itself, and on third party packages such as the great <a href="https://github.com/marcgibbons/django-rest-framework-docs">django-rest-framework-docs</a> package from <a href="https://github.com/marcgibbons/">Marc Gibbons</a>.</p>
 <hr />
 <h2 id="api-changes">API changes</h2>
@@ -324,9 +324,9 @@ serializer.data
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/2.3-announcement.html
+++ b/topics/2.3-announcement.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>REST framework 2.3 announcement - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, REST framework 2.3 announcement, API Changes, Other notes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -417,9 +417,9 @@ urlpatterns = [
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/2.4-announcement.html
+++ b/topics/2.4-announcement.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>REST framework 2.4 announcement - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, REST framework 2.4 announcement">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -329,9 +329,9 @@ The lowest supported version of Django is now 1.4.2.</p>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/ajax-csrf-cors.html
+++ b/topics/ajax-csrf-cors.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Working with AJAX, CSRF & CORS - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Working with AJAX, CSRF & CORS">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -237,9 +237,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/browsable-api.html
+++ b/topics/browsable-api.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>The Browsable API - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, The Browsable API">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -332,9 +332,9 @@ class BookSerializer(serializers.ModelSerializer):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/browser-enhancements.html
+++ b/topics/browser-enhancements.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Browser enhancements - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Browser enhancements">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -271,9 +271,9 @@ as well as how to support content types other than form-encoded data.</p>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/contributing.html
+++ b/topics/contributing.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Contributing to REST framework - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Contributing to REST framework, Issues, Development, Documentation, Third party packages">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -373,9 +373,9 @@ More text...
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/credits.html
+++ b/topics/credits.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Credits - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/credits"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Credits">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -389,7 +389,7 @@ a.fusion-poweredby {
 <p>The documentation is built with <a href="http://twitter.github.com/bootstrap/">Bootstrap</a> and <a href="http://daringfireball.net/projects/markdown/">Markdown</a>.</p>
 <p>Project hosting is with <a href="https://github.com/tomchristie/django-rest-framework">GitHub</a>.</p>
 <p>Continuous integration testing is managed with <a href="https://secure.travis-ci.org/tomchristie/django-rest-framework">Travis CI</a>.</p>
-<p>The <a href="http://restframework.herokuapp.com/">live sandbox</a> is hosted on <a href="http://www.heroku.com/">Heroku</a>.</p>
+<p>The <a href="//restframework.herokuapp.com/">live sandbox</a> is hosted on <a href="http://www.heroku.com/">Heroku</a>.</p>
 <p>Various inspiration taken from the <a href="http://rubyonrails.org/">Rails</a>, <a href="https://bitbucket.org/jespern/django-piston">Piston</a>, <a href="https://github.com/toastdriven/django-tastypie">Tastypie</a>, <a href="https://github.com/zacharyvoase/dagny">Dagny</a> and <a href="https://github.com/BertrandBordage/django-viewsets">django-viewsets</a> projects.</p>
 <p>Development of REST framework 2.0 was sponsored by <a href="http://lab.dabapps.com">DabApps</a>.</p>
 <h2 id="contact">Contact</h2>
@@ -410,9 +410,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/documenting-your-api.html
+++ b/topics/documenting-your-api.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Documenting your API - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Documenting your API">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -276,9 +276,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/kickstarter-announcement.html
+++ b/topics/kickstarter-announcement.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Kickstarting Django REST framework 3 - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Kickstarting Django REST framework 3">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -347,9 +347,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/release-notes.html
+++ b/topics/release-notes.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Release Notes - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Release Notes">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -876,9 +876,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/rest-framework-2-announcement.html
+++ b/topics/rest-framework-2-announcement.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Django REST framework 2 - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Django REST framework 2">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -256,7 +256,7 @@ a.fusion-poweredby {
 <h2 id="summary">Summary</h2>
 <p>In short, we've engineered the hell outta this thing, and we're incredibly proud of the result.</p>
 <p>If you're interested please take a browse around the documentation.  <a href="../tutorial/1-serialization">The tutorial</a> is a great place to get started.</p>
-<p>There's also a <a href="http://restframework.herokuapp.com/">live sandbox version of the tutorial API</a> available for testing.</p>
+<p>There's also a <a href="//restframework.herokuapp.com/">live sandbox version of the tutorial API</a> available for testing.</p>
           </div><!--/span-->
         </div><!--/row-->
       </div><!--/.fluid-container-->
@@ -272,9 +272,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/rest-hypermedia-hateoas.html
+++ b/topics/rest-hypermedia-hateoas.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>REST, Hypermedia & HATEOAS - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, REST, Hypermedia & HATEOAS">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -240,9 +240,9 @@ the Design of Network-based Software Architectures</a>.</li>
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/third-party-resources.html
+++ b/topics/third-party-resources.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Third Party Resources - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Third Party Resources">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -304,9 +304,9 @@ a.fusion-poweredby {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/topics/writable-nested-serializers.html
+++ b/topics/writable-nested-serializers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Writable nested serializers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/topics/writable-nested-serializers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/topics/writable-nested-serializers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Writable nested serializers">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -248,9 +248,9 @@ class ToDoListSerializer(serializers.ModelSerializer):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/1-serialization.html
+++ b/tutorial/1-serialization.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 1: Serialization - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 1: Serialization">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -212,7 +212,7 @@ a.fusion-poweredby {
 <p>This tutorial will cover creating a simple pastebin code highlighting Web API.  Along the way it will introduce the various components that make up REST framework, and give you a comprehensive understanding of how everything fits together.</p>
 <p>The tutorial is fairly in-depth, so you should probably get a cookie and a cup of your favorite brew before getting started.  If you just want a quick overview, you should head over to the <a href="quickstart">quickstart</a> documentation instead.</p>
 <hr />
-<p><strong>Note</strong>: The code for this tutorial is available in the <a href="https://github.com/tomchristie/rest-framework-tutorial">tomchristie/rest-framework-tutorial</a> repository on GitHub.  The completed implementation is also online as a sandbox version for testing, <a href="http://restframework.herokuapp.com/">available here</a>.</p>
+<p><strong>Note</strong>: The code for this tutorial is available in the <a href="https://github.com/tomchristie/rest-framework-tutorial">tomchristie/rest-framework-tutorial</a> repository on GitHub.  The completed implementation is also online as a sandbox version for testing, <a href="//restframework.herokuapp.com/">available here</a>.</p>
 <hr />
 <h2 id="setting-up-a-new-environment">Setting up a new environment</h2>
 <p>Before we do anything else we'll create a new virtual environment, using <a href="http://www.virtualenv.org/en/latest/index.html">virtualenv</a>.  This will make sure our package configuration is kept nicely isolated from any other projects we're working on.</p>
@@ -513,9 +513,9 @@ Quit the server with CONTROL-C.
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/2-requests-and-responses.html
+++ b/tutorial/2-requests-and-responses.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 2: Requests and Responses - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 2: Requests and Responses">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -352,9 +352,9 @@ curl -X POST http://127.0.0.1:8000/snippets/ -d '{"code": "print 456"}' -H "Cont
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/3-class-based-views.html
+++ b/tutorial/3-class-based-views.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 3: Class Based Views - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 3: Class Based Views">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -344,9 +344,9 @@ class SnippetDetail(generics.RetrieveUpdateDestroyAPIView):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/4-authentication-and-permissions.html
+++ b/tutorial/4-authentication-and-permissions.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 4: Authentication & Permissions - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 4: Authentication & Permissions">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -380,9 +380,9 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/5-relationships-and-hyperlinked-apis.html
+++ b/tutorial/5-relationships-and-hyperlinked-apis.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 5: Relationships & Hyperlinked APIs - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 5: Relationships & Hyperlinked APIs">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -346,9 +346,9 @@ urlpatterns += [
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/6-viewsets-and-routers.html
+++ b/tutorial/6-viewsets-and-routers.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Tutorial 6: ViewSets & Routers - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Tutorial 6: ViewSets & Routers">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -311,7 +311,7 @@ urlpatterns = [
 <h2 id="reviewing-our-work">Reviewing our work</h2>
 <p>With an incredibly small amount of code, we've now got a complete pastebin Web API, which is fully web browseable, and comes complete with authentication, per-object permissions, and multiple renderer formats.</p>
 <p>We've walked through each step of the design process, and seen how if we need to customize anything we can gradually work our way down to simply using regular Django views.</p>
-<p>You can review the final <a href="https://github.com/tomchristie/rest-framework-tutorial">tutorial code</a> on GitHub, or try out a live example in <a href="http://restframework.herokuapp.com/">the sandbox</a>.</p>
+<p>You can review the final <a href="https://github.com/tomchristie/rest-framework-tutorial">tutorial code</a> on GitHub, or try out a live example in <a href="//restframework.herokuapp.com/">the sandbox</a>.</p>
 <h2 id="onwards-and-upwards">Onwards and upwards</h2>
 <p>We've reached the end of our tutorial.  If you want to get more involved in the REST framework project, here are a few places you can start:</p>
 <ul>
@@ -335,9 +335,9 @@ urlpatterns = [
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()

--- a/tutorial/quickstart.html
+++ b/tutorial/quickstart.html
@@ -3,21 +3,21 @@
 <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <title>Quickstart - Django REST framework</title>
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="canonical" href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart"/>
+    <link href="//tomchristie.github.io/rest-framework-2-docs/img/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="canonical" href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django, API, REST, Quickstart">
     <meta name="author" content="Tom Christie">
 
     <!-- Le styles -->
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="http://tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/prettify.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="//tomchristie.github.io/rest-framework-2-docs/css/default.css" rel="stylesheet">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <script type="text/javascript">
@@ -65,67 +65,67 @@ a.fusion-poweredby {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="http://tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
+          <a class="brand" href="//tomchristie.github.io/rest-framework-2-docs">Django REST framework 2</a>
           <div class="nav-collapse collapse">
             <ul class="nav">
-              <li><a href="http://tomchristie.github.io/rest-framework-2-docs">Home</a></li>
+              <li><a href="//tomchristie.github.io/rest-framework-2-docs">Home</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Tutorial <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/quickstart">Quickstart</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/1-serialization">1 - Serialization</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/2-requests-and-responses">2 - Requests and responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/3-class-based-views">3 - Class based views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/4-authentication-and-permissions">4 - Authentication and permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/5-relationships-and-hyperlinked-apis">5 - Relationships and hyperlinked APIs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/tutorial/6-viewsets-and-routers">6 - Viewsets and routers</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Guide <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/requests">Requests</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/responses">Responses</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/views">Views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/generic-views">Generic views</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/viewsets">Viewsets</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/routers">Routers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/parsers">Parsers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/renderers">Renderers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/serializers">Serializers</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/fields">Serializer fields</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/relations">Serializer relations</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/authentication">Authentication</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/permissions">Permissions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/throttling">Throttling</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/filtering">Filtering</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/pagination">Pagination</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/content-negotiation">Content negotiation</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/format-suffixes">Format suffixes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/reverse">Returning URLs</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/exceptions">Exceptions</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/status-codes">Status codes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/testing">Testing</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/api-guide/settings">Settings</a></li>
                 </ul>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
-                  <li><a href="http://tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/documenting-your-api">Documenting your API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/ajax-csrf-cors">AJAX, CSRF & CORS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browser-enhancements">Browser enhancements</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/browsable-api">The Browsable API</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-hypermedia-hateoas">REST, Hypermedia & HATEOAS</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/third-party-resources">Third Party Resources</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/contributing">Contributing to REST framework</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/rest-framework-2-announcement">2.0 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.2-announcement">2.2 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.3-announcement">2.3 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/2.4-announcement">2.4 Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/kickstarter-announcement">Kickstarter Announcement</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/release-notes">Release Notes</a></li>
+                  <li><a href="//tomchristie.github.io/rest-framework-2-docs/topics/credits">Credits</a></li>
                 </ul>
               </li>
             </ul>
@@ -354,9 +354,9 @@ REST_FRAMEWORK = {
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
-    <script src="http://tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/jquery-1.8.1-min.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/prettify-1.0.js"></script>
+    <script src="//tomchristie.github.io/rest-framework-2-docs/js/bootstrap-2.1.1-min.js"></script>
 
     <script>
       //$('.side-nav').scrollspy()


### PR DESCRIPTION
Since github pages are served under SSL, any included resources also must be.

http://tomchristie -> //tomchristie
http://html5shim -> //html5shim
http://platform.twitter.com/widgets.js -> https://platform.twitter.com/widgets.js
